### PR TITLE
checks if adding the header to a partslist pushes it over the length limit

### DIFF
--- a/Cogs/Hw.py
+++ b/Cogs/Hw.py
@@ -680,7 +680,10 @@ class Hw:
 				return
 		
 		# At this point - we *should* have a user and a build
-		msg = "__**{}'s {}:**__\n\n{}".format(DisplayName.name(memFromName), buildParts['Name'], buildParts['Hardware'])
+		msg_head = "__**{}'s {}:**__\n\n".format(DisplayName.name(memFromName), buildParts['Name'])
+		msg = msg_head + buildParts['Hardware']
+		if len(msg) > 2000: # is there somwhere the discord char count is defined, to avoid hardcoding?
+			msg = buildParts['Hardware'] # if the header pushes us over the limit, omit it and send just the string
 		if self.checkSuppress(ctx):
 			msg = Nullify.clean(msg)
 		await ctx.channel.send(msg)


### PR DESCRIPTION

if so, it omits the header and simply sends the list. Might also have to do the same thing on rawhw because it has a similar issue with partlists very close to 200 chars