### PR TITLE
Prevent the bot from quoting himself

### DIFF
--- a/Cogs/Quote.py
+++ b/Cogs/Quote.py
@@ -35,6 +35,10 @@ class Quote:
 			# Not in a server
 			return
 
+		# Check if the reaction is added by the bot
+		if member.id == self.bot.user.id:
+			return
+
 		r =         self.settings.getServerStat(member.guild, "QuoteReaction")
 		r_channel = self.settings.getServerStat(member.guild, "QuoteChannel")
 		r_admin   = self.settings.getServerStat(member.guild, "QuoteAdminOnly")


### PR DESCRIPTION
For instance if you were to set the quote reaction to :heart: and you would ping pooter, it would quote that message. And this is unwanted behaviour I suppose