### PR TITLE
Added support for adding emojis from referenced messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,8 @@ A list of cogs, commands, and descriptions:
 ####	Emoji Cog (2 commands) - Emoji.py Extension:
 	  $addemoji [emoji] [name]
 	   └─ Adds the passed emoji, url, or attachment as a custom emoji with the passed n...
+	  $addemoji [name] (While replying to a message with an emoji)
+	   └─ Adds the emoji of a referenced message...
 	  $emoji [emoji]
 	   └─ Outputs the passed emoji... but bigger!
 


### PR DESCRIPTION
Added this to make it easier when someone wants an emoji from another server in a current one without having to get URLs. Helps a lot specially on mobile.

I'm not very good with python, so tell me if I made some huge mistake in the code!

Example:
<img width="387" alt="image" src="https://user-images.githubusercontent.com/9410916/121977918-6c721300-cd5d-11eb-94d7-2d9d3409a702.png">
