### PR TITLE
Add HackAudio cog with layouts/alcids command

### DIFF
--- a/Cogs/HackAudio.py
+++ b/Cogs/HackAudio.py
@@ -1,0 +1,38 @@
+from   discord.ext import commands
+from   Cogs import DL
+
+def setup(bot):
+    # Add the bot
+    bot.add_cog(HackAudio(bot))
+
+# layouts/alcid is a simple command that allows members to quickly retrieve all the available
+# layouts for a certain audio codec by *reading* the AppleALC GitHub repository
+
+class HackAudio(commands.Cog):
+    
+	# Init with the bot reference
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.command(aliases=["alcid"])
+    async def layouts(self, ctx, codec : str = None):
+        """Search the AppleALC repository for available codec layouts"""
+
+        if codec is None:
+            return await ctx.send("Usage: `{}layouts [codec]`".format(ctx.prefix))
+
+        layouts = []
+        req_url = "https://api.github.com/repos/acidanthera/AppleALC/contents/Resources/{}".format(codec.upper())
+        # Try to find available layouts and store them in a list
+        try:
+            response = await DL.async_json(req_url)
+            for file in response:
+                if file["name"].startswith("layout"):
+                    layouts.append(file["name"].replace("layout", "").replace(".xml", ""))
+        # No such directory
+        except:
+            return await ctx.send("I couldn't find that codec!")
+
+        msg = '**Available layouts for codec *{}*:**\nlayout {}'.format(codec.upper(), ', '.join(map(str, sorted(layouts, key=len))))
+        await ctx.send(msg)
+        

--- a/Cogs/HackAudio.py
+++ b/Cogs/HackAudio.py
@@ -16,7 +16,7 @@ class HackAudio(commands.Cog):
 
     @commands.command(aliases=["alcids"])
     async def layouts(self, ctx, codec : str = None):
-        """Search the AppleALC repository for available codec layouts"""
+        """Search the AppleALC repository for available codec layouts."""
 
         if codec is None:
             return await ctx.send("Usage: `{}layouts [codec]`".format(ctx.prefix))

--- a/Cogs/HackAudio.py
+++ b/Cogs/HackAudio.py
@@ -5,7 +5,7 @@ def setup(bot):
     # Add the bot
     bot.add_cog(HackAudio(bot))
 
-# layouts/alcid is a simple command that allows members to quickly retrieve all the available
+# layouts/alcids is a simple command that allows members to quickly retrieve all the available
 # layout id's for a certain audio codec by *reading* the AppleALC GitHub repository
 
 class HackAudio(commands.Cog):
@@ -14,7 +14,7 @@ class HackAudio(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
-    @commands.command(aliases=["alcid"])
+    @commands.command(aliases=["alcids"])
     async def layouts(self, ctx, codec : str = None):
         """Search the AppleALC repository for available codec layouts"""
 

--- a/Cogs/HackAudio.py
+++ b/Cogs/HackAudio.py
@@ -6,7 +6,7 @@ def setup(bot):
     bot.add_cog(HackAudio(bot))
 
 # layouts/alcid is a simple command that allows members to quickly retrieve all the available
-# layouts for a certain audio codec by *reading* the AppleALC GitHub repository
+# layout id's for a certain audio codec by *reading* the AppleALC GitHub repository
 
 class HackAudio(commands.Cog):
     

--- a/README.md
+++ b/README.md
@@ -455,6 +455,11 @@ A list of cogs, commands, and descriptions:
 	  $groot 
 	   └─ Who... who are you?
 
+## HackAudio
+####	HackAudio Cog (1 command) - HackAudio.py Extension:
+	  $layouts [codec] (AKA: alcids)
+	   └─ Search the AppleALC repository for available codec layouts.
+
 ## Help
 ####	Help Cog (3 commands) - Help.py Extension:
 	  $dumphelp [tab_indent_count]


### PR DESCRIPTION
A simple command that retrieves available layout id's for a certain audio codec directly from the AppleALC repository

Example:
![image](https://user-images.githubusercontent.com/54438929/125159659-6cf5a200-e181-11eb-9b53-8a8cd28a298e.png)
