### PR TITLE
Attempt to fix iARK command

### DIFF
--- a/Cogs/IntelArk.py
+++ b/Cogs/IntelArk.py
@@ -5,6 +5,7 @@ from   Cogs import Message
 from   Cogs import DL
 from   Cogs import PickList
 import urllib
+import requests
 
 def setup(bot):
 	# Add the bot
@@ -15,18 +16,17 @@ class IntelArk(commands.Cog):
 	def __init__(self, bot):
 		self.bot = bot
 		self.fields = {
-			"ProcessorNumber": "Processor Name",
-			"ProcessorBrandName": "Processor Brand String",
-			"BornOnDate": "Release Date",
-			"ClockSpeed": "Base Clock",
-			"ClockSpeedMax": "Max Clock",
-			"CoreCount": "Cores",
-			"ThreadCount": "Threads",
-			"MaxMem": "Max Memory",
-			"MaxTDP": "Max TDP",
-			"GraphicsModel": "Onboard Graphics",
-			"InstructionSet": "Instruction Set",
-			"InstructionSetExtensions": "Extensions"
+			'CodeNameText': 'Codename',
+			'ProcessorNumber': 'Name',
+			'CoreCount': '# of Cores',
+			'ThreadCount': '# of Threads',
+			'ClockSpeed': 'Base Clock Speed',
+			'ClockSpeedMax': 'Max Clock Speed',
+			'MaxTDP': 'TDP',
+			'MaxMem': 'Max Memory',
+			'ProcessorGraphicsModelId': 'iGPU',
+			'InstructionSet': 'Instruction Set',
+			'InstructionSetExtensions': 'Extensions'
 		}
 
 	@commands.command(pass_context=True, no_pm=True)
@@ -49,51 +49,52 @@ class IntelArk(commands.Cog):
 		if not len(text):
 			await Message.EmbedText(**args).send(ctx)
 			return
+		
+		text = self.simplified_name(text)
 
 		# message = await Message.EmbedText(title="Intel Ark Search",description="Gathering info...",color=ctx.author,footer="Powered by http://ark.intel.com").send(ctx)
 
 		args["description"] = "Gathering info..."
 		message = await Message.EmbedText(**args).send(ctx)
 
-		search_url = "https://odata.intel.com/API/v1_0/Products/Processors()?&$filter=substringof(%27{}%27,ProductName)&$format=json&$top=5".format(urllib.parse.quote(text))
 		try:
-			# Get the response
-			response = await DL.async_json(search_url)
-			response = response["d"]
+			# Query the ARK, and try to return a response
+			response = await self.iark_search(text)
 		except:
 			response = []
+
 		# Check if we got nothing
 		if not len(response):
 			args["description"] = "No results returned for `{}`.".format(text.replace("`","").replace("\\",""))
 			await Message.EmbedText(**args).edit(ctx, message)
 			return
+
 		elif len(response) == 1:
 			# Set it to the first item
 			response = response[0]
+
 		# Check if we got more than one result (either not exact, or like 4790 vs 4790k)
 		elif len(response) > 1:
-			# Check the top result - and if the ProcessorNumber == our search term - we good
-			proc_num = response[0].get("ProcessorNumber","")
-			if proc_num.lower().strip() == text.lower().strip():
-				# found it
-				response = response[0]
-			else:
-				# Not exact - let's give options
-				index, message = await PickList.Picker(
-					message=message,
-					title="Multiple Matches Returned For `{}`:".format(text.replace("`","").replace("\\","")),
-					list=[x["ProcessorNumber"] for x in response],
-					ctx=ctx
-				).pick()
-				if index < 0:
-					args["description"] = "Search cancelled."
-					await Message.EmbedText(**args).edit(ctx, message)
-					return
-				# Got something
-				response = response[index]
+			# Allow the user to choose which one they meant.
+			index, message = await PickList.Picker(
+				message=message,
+				title="Multiple Matches Returned For `{}`:".format(text.replace("`","").replace("\\","")),
+				list=[x["label"] for x in response],
+				ctx=ctx
+			).pick()
+
+			if index < 0:
+				args["description"] = "Search cancelled."
+				await Message.EmbedText(**args).edit(ctx, message)
+				return
+
+			# Got something
+			response = await self.get_match_data(response[index])
+
 		# At this point - we should have a single response
 		# Let's format and display.
 		fields = [{"name":self.fields[x], "value":response.get(x,None), "inline":True} for x in self.fields]
+
 		await Message.Embed(
 			thumbnail=response.get("BrandBadge",None),
 			pm_after=12,
@@ -103,3 +104,77 @@ class IntelArk(commands.Cog):
 			footer="Powered by http://ark.intel.com",
 			color=ctx.author
 			).edit(ctx, message)
+
+	async def get_match_data(self, match):
+		"""Returns the data of a matched entry."""
+
+		text = await DL.async_text('https://ark.intel.com{0}'.format(match.get('prodUrl', '')))
+		lines = text.split('\n')
+		data = {}
+
+		for line_index in range(len(lines)):
+			for key, value in self.fields.items():
+				if 'ptype="processors"' in lines[line_index].lower():
+					data['BrandBadge'] = lines[line_index].split('src="')[1].split('"')[0]
+					
+				if 'data-key="{}"'.format(key.lower()) in lines[line_index].lower():
+					if 'codename' in key.lower():
+						data[key] = lines[line_index + 1].strip().split('>')[1].split('<')[0].replace('Products formerly', '').strip()
+						continue
+					data[key] = lines[line_index + 1].strip().replace("</span>", "")
+
+		return data
+
+
+	async def quick_search(self, search_term):
+		try:
+			# Credits to https://github.com/xiongnemo/arksearch (a fork of major/arksearch) for this.
+			url = (
+				"https://ark.intel.com/libs/apps/intel/arksearch/autocomplete?"
+				+ "_charset_=UTF-8"
+				+ "&locale=en_us"
+				+ "&currentPageUrl=https%3A%2F%2Fark.intel.com%2Fcontent%2Fwww%2Fus%2Fen%2Fark.html"
+				+ "&input_query={0}"
+			)
+
+			res = await DL.async_json(url.format(search_term))
+			return res
+		except Exception as e:
+			return []
+
+	async def iark_search(self, search_term):
+		results = await self.quick_search(self.simplified_name(search_term))
+
+		return results
+
+	def simplified_name(self, search_term):
+		replace_dict = {
+			"(R)": "®",
+			"(TM)": "™",
+			"(C)": "©",
+			"(P)": "℗",
+			"(G)": "℠",
+			"CPU": "",
+			"@": "",
+		}
+
+		for key, val in replace_dict.items():
+			if key in search_term:
+				search_term = search_term.replace(key, val)
+
+		sanitised_term = ""
+		sanitised = search_term.split(' ')
+
+		if len(sanitised) == 1:
+			return search_term
+		elif len(sanitised) == 2:
+			return "-".join(sanitised)
+
+		for i in range(len(sanitised)):
+			if i == (len(sanitised) - 2):
+				sanitised_term += sanitised[i] + '-' + sanitised[i + 1]
+				break
+		
+			sanitised_term += sanitised[i] + ' '
+
+		return sanitised_term


### PR DESCRIPTION
Previously, the `iARK` command was broken due to Intel shutting down their official developer API.

Recently, there's been an announcement that Intel is publishing a new API, but sadly, for now, this is closed out and only available to whitelisted users/API keys.

For the time being, the implementation here is that we scrape [the intel ARK site](https://ark.intel.com) with the provided search term.

There _are_ a few things that are bugged out/acting strangely. For example, in Pooter's codebase, this query will fail: `intel core i5 8400` (possibly due to aiohttp), whilst in a playground environment that uses `requests`—it will not.

With that, everything else seems to be working, the following data will be displayed to the user, if available:

- Codename
- Processor name
- Core count
- Thread count
- Base clock speed
- Max clock speed
- TDP
- Max Memory
- iGPU (Integrated Graphics)
- Instruction Set
- Instruction Set Extensions