### PR TITLE
Attempt to fix minor bugs wit iARK

### DIFF
--- a/Cogs/IntelArk.py
+++ b/Cogs/IntelArk.py
@@ -5,7 +5,6 @@ from   Cogs import Message
 from   Cogs import DL
 from   Cogs import PickList
 import urllib
-import requests
 
 def setup(bot):
 	# Add the bot
@@ -202,25 +201,29 @@ class IntelArk(commands.Cog):
 			"(G)": "℠",
 			"CPU": "",
 			"@": "",
+			" ": "%20"
 		}
 
 		for key, val in replace_dict.items():
 			if key in search_term:
 				search_term = search_term.replace(key, val)
 
-		sanitised_term = ""
-		sanitised = search_term.split(' ')
+		if not "-" in search_term:
+			sanitised_term = ""
+			sanitised = search_term.split('%20')
 
-		if len(sanitised) == 1:
+			if len(sanitised) == 1:
+				return search_term
+			elif len(sanitised) == 2:
+				return "-".join(sanitised)
+
+			for i in range(len(sanitised)):
+				if i == (len(sanitised) - 2) and not "-" in search_term:
+					sanitised_term += sanitised[i] + '-' + sanitised[i + 1]
+					break
+			
+				sanitised_term += sanitised[i] + '%20' if i != (len(sanitised) - 1) else ''
+
+			return sanitised_term
+		else:
 			return search_term
-		elif len(sanitised) == 2:
-			return "-".join(sanitised)
-
-		for i in range(len(sanitised)):
-			if i == (len(sanitised) - 2):
-				sanitised_term += sanitised[i] + '-' + sanitised[i + 1]
-				break
-		
-			sanitised_term += sanitised[i] + ' '
-
-		return sanitised_term


### PR DESCRIPTION
There are a few bugs with the `iARK` command (per my ignorancy), which include, and are sadly likely not limited to:

- Using a query with the core/xeon name and a revision afterwards, for example `e3 1505m v5` yields nothing. 

   - This is because, we're meant to replace the space between `e3` and `1505m` with a `-`, which we currently cannot do. 

   - However, what we can do is have the user supply that `-` always, and then the rest of the query can be formatted normally.

- Using a query for 10th and 11th gen cores will fail, as it's required to query them as `<brand modifier>-<generation indicator><SKU><Product Line>` (i.e. `i7-1065G7`)

   - For the time being, there is no way around this. Later on, we will likely need to implement a hardcoded scheme for every naming scheme of Intel's processors, and update the user's query accordingly. This will take quite awhile.