### PR TITLE
Use py-cpuinfo to show Processor model in $hostinfo

### DIFF
--- a/Cogs/Bot.py
+++ b/Cogs/Bot.py
@@ -1,4 +1,4 @@
-import asyncio, discord, os, re, psutil, platform, time, sys, fnmatch, subprocess, speedtest, json, struct, shutil, tempfile
+import asyncio, cpuinfo, discord, os, re, psutil, platform, time, sys, fnmatch, subprocess, speedtest, json, struct, shutil, tempfile
 from   PIL         import Image
 from   discord.ext import commands
 from   Cogs import Utils, Settings, DisplayName, ReadableTime, GetImage, ProgressBar, Message, DL
@@ -243,6 +243,7 @@ class Bot(commands.Cog):
 
 		# cpuCores    = psutil.cpu_count(logical=False)
 		# cpuThred    = psutil.cpu_count()
+		cpuName       = cpuinfo.get_cpu_info()['brand_raw']
 		cpuThred      = os.cpu_count()
 		cpuUsage      = psutil.cpu_percent(interval=1)
 		memStats      = psutil.virtual_memory()
@@ -272,11 +273,12 @@ class Bot(commands.Cog):
 
 		msg = '***{}\'s*** **Home:**\n'.format(botName)
 		msg += '```\n'
-		msg += 'OS       : {}\n'.format(currentOS)
+		msg += 'OS        : {}\n'.format(currentOS)
 		if not self.settings.getGlobalStat("HideHostname",False):
-			msg += 'Hostname : {}\n'.format(platform.node())
-		msg += 'Language : Python {}.{}.{} {} ({} bit)\n'.format(pythonMajor, pythonMinor, pythonMicro, pythonRelease, pyBit)
-		msg += 'Commit   : {}\n\n'.format(git_head_hash.decode("utf-8"))
+			msg += 'Hostname  : {}\n'.format(platform.node())
+		msg += 'Processor : {}\n'.format(cpuName)
+		msg += 'Language  : Python {}.{}.{} {} ({} bit)\n'.format(pythonMajor, pythonMinor, pythonMicro, pythonRelease, pyBit)
+		msg += 'Commit    : {}\n\n'.format(git_head_hash.decode("utf-8"))
 		msg += ProgressBar.center('{}% of {} {}'.format(cpuUsage, cpuThred, threadString), 'CPU') + '\n'
 		msg += ProgressBar.makeBar(int(round(cpuUsage))) + "\n\n"
 		msg += ProgressBar.center('{} ({}%) of {}GB used'.format(memUsedGB, memPerc, memTotalGB), 'RAM') + '\n'

--- a/Install.py
+++ b/Install.py
@@ -231,7 +231,8 @@ if __name__ == '__main__':
         {"name":"pymongo"},
         {"name":"geopy"},
         {"name":"pyfiglet"},
-        {"name":"regex"}
+        {"name":"regex"},
+        {"name":"py-cpuinfo"}
     ])
     db_path = os.path.join(os.path.dirname(os.path.realpath(__file__)),"Cogs","PandorasDB.py")
     if os.path.exists(db_path):


### PR DESCRIPTION
Graciously provided by @ThatStella7922, I just decided to jam her code in and it worked. PR adds a dependency on `py-cpuinfo` that gets installed to the venv, then it just works.

Should work fine on all OSes that the bot supports. (I have tested macOS and Linux, but `py-cpuinfo` supports anything that runs Python as well.)

<img width="648" alt="Screenshot 2024-12-03 at 12 00 59" src="https://github.com/user-attachments/assets/490b5ddf-0984-4faa-84db-19b96bfa76d8">
