### PR TITLE
Improve the Profile.py $rawprofile Command

### DIFF
--- a/Cogs/Profile.py
+++ b/Cogs/Profile.py
@@ -1,4 +1,5 @@
 import asyncio, discord, time, shutil, os, tempfile, json
+import re
 from   operator import itemgetter
 from   discord.ext import commands
 from   Cogs import Utils, Settings, ReadableTime, DisplayName, Message, Nullify, PickList, DL
@@ -112,11 +113,28 @@ class Profile(commands.Cog):
 		if item is None:
 			# Just got a member - list their profiles
 			return await self._list_profiles(ctx,member.id)
+		def _format_codeblock(contents=""):
+			return "```markdown\n{}\n```".format(contents.replace("```", "`\uFEFF`\uFEFF`"))
+		def _format_raw(contents=""): # Format the contents to properly display all characters without letting Discord format it.
+			contents = discord.utils.escape_markdown(item['URL'])
+			pattern = re.compile(r"(#{1,3}|-#|-\s*|>(>>)?) ")
+			number_prefix_pattern = re.compile(r"\d+\. [^\n]+")
+			lines = []
+			for line in contents.splitlines():
+				if number_prefix_pattern.search(line):
+					i = line.find(".")
+					if i != -1:
+						line = line[:i] + "\\" + line[i:] # Escape number lists manually
+				elif pattern.search(line):
+					line = "\\" + line
+				lines.append(line)
+			contents = "\n".join(lines)
+			return contents
 		msg = '*{}\'s {}{} Profile:*\n\n{}'.format(
 			DisplayName.name(member),
 			"Raw " if raw else "",
 			Nullify.escape_all(item['Name']),
-			"```markdown\n{}\n```".format(item['URL'].replace("```", "`\u200b``")) if raw else item['URL']
+			_format_raw(item['URL']) if raw else item['URL']
 		)
 		return await ctx.send(Utils.suppressed(ctx,msg))
 

--- a/Cogs/Profile.py
+++ b/Cogs/Profile.py
@@ -116,7 +116,7 @@ class Profile(commands.Cog):
 			DisplayName.name(member),
 			"Raw " if raw else "",
 			Nullify.escape_all(item['Name']),
-			discord.utils.escape_markdown(item['URL']) if raw else item['URL']
+			"```markdown\n{}\n```".format(item['URL']) if raw else item['URL']
 		)
 		return await ctx.send(Utils.suppressed(ctx,msg))
 

--- a/Cogs/Profile.py
+++ b/Cogs/Profile.py
@@ -116,7 +116,7 @@ class Profile(commands.Cog):
 			DisplayName.name(member),
 			"Raw " if raw else "",
 			Nullify.escape_all(item['Name']),
-			"```markdown\n{}\n```".format(item['URL']) if raw else item['URL']
+			"```markdown\n{}\n```".format(item['URL'].replace("```", "`\u200b``")) if raw else item['URL']
 		)
 		return await ctx.send(Utils.suppressed(ctx,msg))
 


### PR DESCRIPTION
Instead of using `discord.utils.escape_markdown(item['URL'])` alone, which doesn't properly escape things like titles, subtitles, and many more - as seen in this example:

<img width="234" height="205" alt="Screenshot from 2025-07-19 15-24-42" src="https://github.com/user-attachments/assets/312ca987-5de2-415c-b540-5b1abe33274b" />

I've changed the message logic to use a new function that properly escapes certain effects and prefixes:

```python
msg = '*{}\'s {}{} Profile:*\n\n{}'.format(
	DisplayName.name(member),
	"Raw " if raw else "",
	Nullify.escape_all(item['Name']),
	_format_raw(item['URL']) if raw else item['URL']
)
```

```python
def _format_raw(contents=""): # Format the contents to properly display all characters without letting Discord format it.
	contents = discord.utils.escape_markdown(item['URL'])
	pattern = re.compile(r"#{1,3}|-#|[->] ")
	number_prefix_pattern = re.compile(r"\d+\. [^\n]+")
	lines = []
	for line in contents.splitlines():
		if number_prefix_pattern.search(line):
			i = line.find(".")
			if i != -1:
				line = line[:i] + "\\" + line[i:] # Escape number lists manually
		elif pattern.search(line):
			line = "\\" + line
		lines.append(line)
	contents = "\n".join(lines)
	return contents
```

This will format profiles like the following:

<img width="243" height="183" alt="Screenshot from 2025-07-19 21-04-31" src="https://github.com/user-attachments/assets/743466a4-4b88-4588-af95-5f8d2f9a7a7b" />
<img width="190" height="188" alt="Screenshot from 2025-07-19 21-04-19" src="https://github.com/user-attachments/assets/4bb73d66-4581-4532-b61b-02c81b3b6cff" />
<img width="233" height="162" alt="Screenshot from 2025-07-19 21-04-10" src="https://github.com/user-attachments/assets/3e853955-204b-47e2-bd4d-9df470ef3eca" />

This makes it a lot easier to edit heavily-formatted profiles, or transfer profiles across servers, as previously, you would have to use `Copy Text` and edit out the top line (like *`Caleb's codeblock Profile:`*).

<sub>Note: `_format_codeblock` is included for the ability to format as a markdown code block, but it doesn't work with nested code blocks.</sub>
I have tested this with my own bot instance, but let me know if you find other issues while the PR is still pending and I can work on it!