### PR TITLE
Added $mem for converting MB to lhex and vise-versa

### DIFF
--- a/Cogs/Encode.py
+++ b/Cogs/Encode.py
@@ -530,3 +530,53 @@ class Encode(commands.Cog):
 			return await ctx.send(Nullify.escape_all(self._convert_value(value,from_type,to_type)))
 		except Exception as e:
 			return await ctx.send(Nullify.escape_all("I couldn't make that conversion:\n{}".format(e)))
+
+	@commands.command(aliases=["fbmem", "stolenmem", "unifiedmem", "cursormem"])
+	async def mem(self, ctx, *, input=None):
+		"""Converts between MiB and little-endian hexadecimal (lhex) for calculating stolenmem, fbmem, etc. values."""
+		usage = 'Usage: `{}mem [input] (e.g. 26MB or 0000A001)`'.format(ctx.prefix)
+		if input is None:
+			return await ctx.send(usage)
+
+		try:
+			val = input.strip()
+			mib = ["mib", "mb", "m"]
+
+			# Determine if the input value is MiB or lhex.
+			is_mib = any(x in val.lower() for x in mib)
+			is_lhex = len(self._check_hex(val))
+			if not is_mib and not is_lhex:
+				return await ctx.send(usage)
+			# Set the from and to type based on the above check.
+			if is_mib:
+				from_type = "mib"
+				to_type = "lhex"
+			else:
+				from_type = "lhex"
+				to_type = "mib"
+
+			# Convert MiB to lhex
+			if from_type == "mib" and to_type == "lhex":
+				# Store as a float and remove mib/mb/m
+				num = float(re.sub('|'.join(mib), '', val.lower()).strip())
+				# Convert to bytes
+				bytes_val = int(num * 1024 * 1024)
+				# Format from an int to a hex value and pre-pad with 8 characters
+				hex_val = "{:08x}".format(bytes_val)
+				# Convert from hex to lhex
+				out = self._convert_value(hex_val, "hex", "lhex")
+				return await ctx.send(Nullify.escape_all(self._check_hex(out)))
+			# Seacrest out!
+
+			# Convert lhex to MiB
+			elif from_type == "lhex" and to_type == "mib":
+				# Convert from lhex to decimal
+				dec_val = self._convert_value(val, "lhex", "decimal")
+				# Convert to MiB
+				mib_val = round(int(dec_val) / (1024 * 1024), 4)
+				return await ctx.send(f"{mib_val} MiB")
+			else:
+				return await ctx.send(usage)
+		except Exception:
+			return await ctx.send(
+				Nullify.escape_all("I couldn't make that conversion!"))

--- a/Cogs/Encode.py
+++ b/Cogs/Encode.py
@@ -534,49 +534,29 @@ class Encode(commands.Cog):
 	@commands.command(aliases=["fbmem", "stolenmem", "unifiedmem", "cursormem"])
 	async def mem(self, ctx, *, input=None):
 		"""Converts between MiB and little-endian hexadecimal (lhex) for calculating stolenmem, fbmem, etc. values."""
+
 		usage = 'Usage: `{}mem [input] (e.g. 26MB or 0000A001)`'.format(ctx.prefix)
 		if input is None:
 			return await ctx.send(usage)
 
 		try:
 			val = input.strip()
-			mib = ["mib", "mb", "m"]
+			# Determine if the input value is MiB. If not MiB, will assume the input is lhex and will catch bad input with the try/except.
+			is_mib = "m" in val.lower()
 
-			# Determine if the input value is MiB or lhex.
-			is_mib = any(x in val.lower() for x in mib)
-			is_lhex = len(self._check_hex(val))
-			if not is_mib and not is_lhex:
-				return await ctx.send(usage)
-			# Set the from and to type based on the above check.
+			# Convert MiB to lhex:
 			if is_mib:
-				from_type = "mib"
-				to_type = "lhex"
+				# Store as a float and only store "0-9" and "." - ignoring other characters.
+				num = float("".join([x for x in val if x in "01234596789."]))
+				# Convert to bytes:
+				bytes_val = int(num * 1024 ** 2)
+				# Convert from decimal to lhex (using _check_hex to omit `0x` in the output). Using lhex32 which will auto-pad.
+				return await ctx.send(self._check_hex(self._convert_value(bytes_val, "decimal", "lhex32")))
 			else:
-				from_type = "lhex"
-				to_type = "mib"
-
-			# Convert MiB to lhex
-			if from_type == "mib" and to_type == "lhex":
-				# Store as a float and remove mib/mb/m
-				num = float(re.sub('|'.join(mib), '', val.lower()).strip())
-				# Convert to bytes
-				bytes_val = int(num * 1024 * 1024)
-				# Format from an int to a hex value and pre-pad with 8 characters
-				hex_val = "{:08x}".format(bytes_val)
-				# Convert from hex to lhex
-				out = self._convert_value(hex_val, "hex", "lhex")
-				return await ctx.send(Nullify.escape_all(self._check_hex(out)))
-			# Seacrest out!
-
-			# Convert lhex to MiB
-			elif from_type == "lhex" and to_type == "mib":
-				# Convert from lhex to decimal
-				dec_val = self._convert_value(val, "lhex", "decimal")
-				# Convert to MiB
-				mib_val = round(int(dec_val) / (1024 * 1024), 4)
+				# Convert from lhex to decimal:
+				dec_val = self._convert_value(val, "lhex32", "decimal")
+				# Convert to MiB (using abs to ensure we always get a positive value):
+				mib_val = round(abs(int(dec_val)) / (1024 ** 2), 4)
 				return await ctx.send(f"{mib_val} MiB")
-			else:
-				return await ctx.send(usage)
 		except Exception:
-			return await ctx.send(
-				Nullify.escape_all("I couldn't make that conversion!"))
+			return await ctx.send("I couldn't make that conversion!")

--- a/README.md
+++ b/README.md
@@ -453,6 +453,8 @@ A list of cogs, commands, and descriptions:
 	   └─ Byte swaps the passed hex value.
 	  $intbin [input_int]
 	   └─ Converts the input integer to its binary representation.
+	  $mem [input] (AKA: fbmem, stolenmem, unifiedmem, cursormem)
+	   └─ Converts between MiB and little-endian hexadecimal (lhex) for calculating fbm...
 	  $randomcolor 
 	   └─ Selects a random color.
 	  $strbin [input_string]


### PR DESCRIPTION
Can also be used with the following aliases: `$fbmem`, `$stolenmem`, `$unifiedmem`, and `$cursormem`.

Usage example:
`$stolenmem 26m`

`$fbmem 00009000`

`$mem 0x00000006`

`$cursormem 1MB`

<img width="307" height="146" alt="Screenshot 2026-03-23 at 12 29 17 AM" src="https://github.com/user-attachments/assets/b938e1f1-f7cb-49ec-b225-64b0d8df9e5a" />
<img width="289" height="146" alt="Screenshot 2026-03-23 at 12 33 42 AM" src="https://github.com/user-attachments/assets/85b3c8fa-38f7-476e-837a-8f70576bf664" />
